### PR TITLE
Typo in a variable name

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -6,12 +6,11 @@ var pg = require('pg');
 //or native libpq bindings
 //var pg = require('pg').native
 
-var connection_string = process.env.DATABASE_URL;
 var client;
 var client_active = false;
 
-module.exports.init = function(conenction_string){
-  client = new pg.Client(connection_string);
+module.exports.init = function(connection_string){
+  client = new pg.Client(connection_string || process.env.DATABASE_URL);
 }
 
 module.exports.query = function(query, callback){


### PR DESCRIPTION
There was a typo in the `db#init` function preventing passing the connection string as a parameter. The only value used was the one defined by the `DATABASE_URL` env